### PR TITLE
move mutex unlock before bot update goroutine

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -164,11 +164,12 @@ func (d *Dispatcher) listen() {
 		if _, isIn := d.sessionMap[chatID]; !isIn {
 			d.sessionMap[chatID] = d.newBot(chatID)
 		}
+		bot, ok := d.sessionMap[chatID]
+		d.mu.Unlock()
 
-		if bot, ok := d.sessionMap[chatID]; ok {
+		if ok {
 			go bot.Update(update)
 		}
-		d.mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
Hello! I am new to Go and currently learning it by reading the source code. I love coding async bots on Python and now want to do almost the same with goroutines. I spot that mutex unlock call is after goroutine, isn't it bad? If it isn't, can you explain me why? Thanks for the library!