### PR TITLE
Update Telegram Bot API 5.4

### DIFF
--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ const (
 	FindLocation               = "find_location"
 	RecordVideoNote            = "record_video_note"
 	UploadVideoNote            = "upload_video_note"
+	ChooseSticker              = "choose_sticker"
 )
 
 // UpdateType is a custom type for the various update types that a bot can be subscribed to.
@@ -434,8 +435,10 @@ type UserProfileOptions struct {
 
 // InviteLinkOptions contains the optional parameters used by the CreateChatInviteLink and EditChatInviteLink methods.
 type InviteLinkOptions struct {
-	ExpireDate  int64 `query:"expire_date"`
-	MemberLimit int   `query:"member_limit"`
+	Name               string `query:"name"`
+	ExpireDate         int64  `query:"expire_date"`
+	MemberLimit        int    `query:"member_limit"`
+	CreatesJoinRequest bool   `query:"creates_join_request"`
 }
 
 // CallbackQueryOptions contains the optional parameters used by the AnswerCallbackQuery method.

--- a/types.go
+++ b/types.go
@@ -519,7 +519,7 @@ type ChatInviteLink struct {
 	Name                    string `json:"name,omitempty"`
 	ExpireDate              int    `json:"expire_date,omitempty"`
 	MemberLimit             int    `json:"member_limit,omitempty"`
-	PendingJoinRequestCount int    `json:pending_join_request_count,omitempty`
+	PendingJoinRequestCount int    `json:"pending_join_request_count,omitempty"`
 }
 
 // ChatMember contains information about one member of a chat.

--- a/types.go
+++ b/types.go
@@ -31,6 +31,9 @@ type Update struct {
 	InlineQuery        *InlineQuery        `json:"inline_query,omitempty"`
 	ChosenInlineResult *ChosenInlineResult `json:"chosen_inline_result,omitempty"`
 	CallbackQuery      *CallbackQuery      `json:"callback_query,omitempty"`
+	MyChatMember       *ChatMemberUpdated  `json:"my_chat_member,omitempty"`
+	ChatMember         *ChatMemberUpdated  `json:"chat_member,omitempty"`
+	ChatJoinRequest    *ChatJoinRequest    `json:"chat_join_request,omitempty"`
 }
 
 // WebhookInfo contains information about the current status of a webhook.
@@ -508,12 +511,15 @@ type ChatPhoto struct {
 
 // ChatInviteLink represents an invite link for a chat.
 type ChatInviteLink struct {
-	InviteLink  string `json:"invite_link"`
-	Creator     *User  `json:"creator"`
-	IsPrimary   bool   `json:"is_primary"`
-	IsRevoked   bool   `json:"is_revoked"`
-	ExpireDate  int    `json:"expire_date,omitempty"`
-	MemberLimit int    `json:"member_limit,omitempty"`
+	InviteLink              string `json:"invite_link"`
+	Creator                 *User  `json:"creator"`
+	CreatesJoinRequest      bool   `json:"creates_join_request"`
+	IsPrimary               bool   `json:"is_primary"`
+	IsRevoked               bool   `json:"is_revoked"`
+	Name                    string `json:"name,omitempty"`
+	ExpireDate              int    `json:"expire_date,omitempty"`
+	MemberLimit             int    `json:"member_limit,omitempty"`
+	PendingJoinRequestCount int    `json:pending_join_request_count,omitempty`
 }
 
 // ChatMember contains information about one member of a chat.
@@ -806,4 +812,12 @@ type BotCommandScope struct {
 // PermissionOptions is a custom type used to allow proper serialization of ChatPermissions-type parameters in some methods.
 type PermissionOptions struct {
 	Permissions ChatPermissions `json:"permissions"`
+}
+
+type ChatJoinRequest struct {
+	Chat       Chat            `json:"chat"`
+	From       User            `json:"user"`
+	Date       int             `json:"date"`
+	Bio        string          `json:"bio,omitempty"`
+	InviteLink *ChatInviteLink `json:"invite_link,omitempty"`
 }


### PR DESCRIPTION
You might want to change `ChatInviteLinkOption` since `member_limit` and `creates_join_request` cannot be specified together 
https://core.telegram.org/bots/api#createchatinvitelink