### PR TITLE
Feature/set custom httpserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# echotron 
+# echotron
 
 | <br/><img src="assets/logo.png" alt="logo" width="400"><br/><br/> [![Language](https://img.shields.io/badge/Language-Go-blue.svg)](https://golang.org/) [![PkgGoDev](https://pkg.go.dev/badge/github.com/NicoNex/echotron/v3)](https://pkg.go.dev/github.com/NicoNex/echotron/v3) [![Go Report Card](https://goreportcard.com/badge/github.com/NicoNex/echotron)](https://goreportcard.com/report/github.com/NicoNex/echotron) [![License](http://img.shields.io/badge/license-LGPL3.0-orange.svg?style=flat)](https://github.com/NicoNex/echotron/blob/master/LICENSE) [![Build Status](https://travis-ci.com/NicoNex/echotron.svg?branch=master)](https://travis-ci.com/NicoNex/echotron) [![Coverage Status](https://coveralls.io/repos/github/NicoNex/echotron/badge.svg?branch=master)](https://coveralls.io/github/NicoNex/echotron?branch=master) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go) [![Telegram](https://img.shields.io/badge/Echotron%20News-blue?logo=telegram&style=flat)](https://t.me/echotronnews) |
 | :------: |
@@ -216,7 +216,7 @@ func main() {
 	// Capture the interrupt signal for app termination handling
 	dsp := echotron.NewDispatcher(token, newBot)
 	dsp.SetHTTPServer(server)
-	// Start your custom http.Server with a registered /webhook handler. 
-	log.Println(dsp.ListenWebhook("https://example.com/webhook"))
+	// Start your custom http.Server with a registered /my_bot_token handler.
+	log.Println(dsp.ListenWebhook("https://example.com/my_bot_token"))
 }
 ```

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -48,7 +48,7 @@ type Dispatcher struct {
 	sessionMap map[int64]Bot
 	newBot     NewBotFn
 	updates    chan *Update
-	handler    http.Handler
+	httpServer *http.Server
 	mu         sync.Mutex
 }
 
@@ -61,7 +61,7 @@ func NewDispatcher(token string, newBotFn NewBotFn) *Dispatcher {
 		sessionMap: make(map[int64]Bot),
 		newBot:     newBotFn,
 		updates:    make(chan *Update),
-		handler:    nil,
+		httpServer: nil,
 	}
 	go d.listen()
 	return d
@@ -202,17 +202,19 @@ func (d *Dispatcher) ListenWebhookOptions(webhookURL string, dropPendingUpdates 
 	if err != nil {
 		return err
 	} else if response.Ok {
+		if d.httpServer != nil {
+			return d.httpServer.ListenAndServe()
+		}
 		http.HandleFunc(u.EscapedPath(), d.HandleWebhook)
 		log.Printf("listening on :%s\n", u.Port())
-		return http.ListenAndServe(fmt.Sprintf(":%s", u.Port()), d.handler)
+		return http.ListenAndServe(fmt.Sprintf(":%s", u.Port()), nil)
 	}
-
 	return fmt.Errorf("could not set webhook: %d %s", response.ErrorCode, response.Description)
 }
 
-// SetHTTPHandler allows to set a custom http.Handler for ListenWebhook and ListenWebhookOptions.
-func (d *Dispatcher) SetHTTPHandler(h http.Handler) {
-	d.handler = h
+// SetHTTPServer allows to set a custom http.Server for ListenWebhook and ListenWebhookOptions.
+func (d *Dispatcher) SetHTTPServer(s *http.Server) {
+	d.httpServer = s
 }
 
 // HandleWebhook is the http.HandlerFunc for the webhook URL.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -200,6 +200,10 @@ func (d *Dispatcher) ListenWebhookOptions(webhookURL string, dropPendingUpdates 
 	}
 
 	if d.httpServer != nil {
+		mux := http.NewServeMux()
+		mux.Handle("/", d.httpServer.Handler)
+		mux.HandleFunc(u.EscapedPath(), d.HandleWebhook)
+		d.httpServer.Handler = mux
 		return d.httpServer.ListenAndServe()
 	}
 	http.HandleFunc(u.EscapedPath(), d.HandleWebhook)


### PR DESCRIPTION
Hi @NicoNex,

I was wondering if it will be better to pass a pointer to an http.Server instead of the http.Handler because then, the user of the your library has more control and can for example, initiate a gracefully server shutdown by himself.
I know that this will bring braking changes, and I'm sad that I don't came up earlier with this idea, but maybe you can consider the change for the next major version. Thanks in advance.