### PR TITLE
Added dsp.Stop() and Updated dispatcher tests

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -18,158 +18,75 @@ func TestNewDispatcher(t *testing.T) {
 }
 
 func TestAddSession(t *testing.T) {
-	dsp.AddSession(0)
+	err := dsp.AddSession(0)
+	if err != nil {
+		t.Fatalf("could not add session: %v", err)
+	}
 
-	if len(dsp.sessionMap) == 0 {
-		t.Fatal("could not add session")
+	_, ok := dsp.sessionMap.Load(int64(0))
+	if !ok {
+		t.Fatal("could not find added session")
 	}
 }
 
 func TestDelSession(t *testing.T) {
 	dsp.DelSession(0)
 
-	if len(dsp.sessionMap) != 0 {
-		t.Fatal("could not delete session")
+	_, ok := dsp.sessionMap.Load(int64(0))
+	if ok {
+		t.Fatal("session was not deleted")
 	}
 }
 
 func TestListenWebhook(_ *testing.T) {
-	dsp.ListenWebhook("http://example.com:8443/test")
+	go func() {
+		_ = dsp.ListenWebhook("http://example.com:8443/test")
+	}()
 	time.Sleep(time.Second)
 }
 
-func TestPoll(_ *testing.T) {
-	dsp.Poll()
+func TestPoll(t *testing.T) {
+	go func() {
+		_ = dsp.Poll()
+	}()
 
-	dsp.updates <- &Update{}
+	// Wait a bit for polling to start
+	time.Sleep(time.Millisecond * 100)
 
-	dsp.updates <- &Update{
-		ChatJoinRequest: &ChatJoinRequest{
-			Chat: Chat{ID: 0},
-		},
+	updates := []Update{
+		{ChatJoinRequest: &ChatJoinRequest{Chat: Chat{ID: 0}}},
+		{ChatBoost: &ChatBoostUpdated{Chat: Chat{ID: 0}}},
+		{RemovedChatBoost: &ChatBoostRemoved{Chat: Chat{ID: 0}}},
+		{Message: &Message{Chat: Chat{ID: 0}}},
+		{EditedMessage: &Message{Chat: Chat{ID: 0}}},
+		{ChannelPost: &Message{Chat: Chat{ID: 0}}},
+		{EditedChannelPost: &Message{Chat: Chat{ID: 0}}},
+		{BusinessConnection: &BusinessConnection{User: User{ID: 0}}},
+		{BusinessMessage: &Message{Chat: Chat{ID: 0}}},
+		{EditedBusinessMessage: &Message{Chat: Chat{ID: 0}}},
+		{DeletedBusinessMessages: &BusinessMessagesDeleted{Chat: Chat{ID: 0}}},
+		{MessageReaction: &MessageReactionUpdated{Chat: Chat{ID: 0}}},
+		{MessageReactionCount: &MessageReactionCountUpdated{Chat: Chat{ID: 0}}},
+		{InlineQuery: &InlineQuery{From: &User{ID: 0}}},
+		{ChosenInlineResult: &ChosenInlineResult{From: &User{ID: 0}}},
+		{CallbackQuery: &CallbackQuery{Message: &Message{Chat: Chat{ID: 0}}}},
+		{ShippingQuery: &ShippingQuery{From: User{ID: 0}}},
+		{PreCheckoutQuery: &PreCheckoutQuery{From: User{ID: 0}}},
+		{PollAnswer: &PollAnswer{User: &User{ID: 0}}},
+		{MyChatMember: &ChatMemberUpdated{Chat: Chat{ID: 0}}},
+		{ChatMember: &ChatMemberUpdated{Chat: Chat{ID: 0}}},
 	}
 
-	dsp.updates <- &Update{
-		ChatBoost: &ChatBoostUpdated{
-			Chat: Chat{ID: 0},
-		},
+	for _, update := range updates {
+		dsp.updates <- &update
 	}
 
-	dsp.updates <- &Update{
-		RemovedChatBoost: &ChatBoostRemoved{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		Message: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		EditedMessage: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		ChannelPost: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		EditedChannelPost: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		BusinessConnection: &BusinessConnection{
-			User: User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		BusinessMessage: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		EditedBusinessMessage: &Message{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		DeletedBusinessMessages: &BusinessMessagesDeleted{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		MessageReaction: &MessageReactionUpdated{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		MessageReactionCount: &MessageReactionCountUpdated{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		InlineQuery: &InlineQuery{
-			From: &User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		ChosenInlineResult: &ChosenInlineResult{
-			From: &User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		CallbackQuery: &CallbackQuery{
-			Message: &Message{
-				Chat: Chat{ID: 0},
-			},
-		},
-	}
-
-	dsp.updates <- &Update{
-		ShippingQuery: &ShippingQuery{
-			From: User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		PreCheckoutQuery: &PreCheckoutQuery{
-			From: User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		PollAnswer: &PollAnswer{
-			User: &User{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		MyChatMember: &ChatMemberUpdated{
-			Chat: Chat{ID: 0},
-		},
-	}
-
-	dsp.updates <- &Update{
-		ChatMember: &ChatMemberUpdated{
-			Chat: Chat{ID: 0},
-		},
-	}
-
+	// Wait for updates to be processed
 	time.Sleep(time.Second)
+
+	// Stop polling
+	err := dsp.Stop()
+	if err != nil {
+		t.Fatal("Failed to stop dispatcher: %v", err)
+	}
 }


### PR DESCRIPTION
The use of sync.Map for sessionMap improves thread safety. 
sync.Map eliminates the need for manual locking in most places. 
The PollOptions function now uses a context with timeout, which helps manage long-polling operations more effectively. 
The getUpdatesWithTimeout function provides a good mechanism to handle timeouts and other errors from the Telegram API. 
The Stop method has a timeout mechanism to prevent indefinite hanging.

![image](https://github.com/user-attachments/assets/b62a2436-818c-45be-8370-72c7fad10863)